### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![smithery badge](https://smithery.ai/badge/@gourav221b/Github-PR-MCP-server)](https://smithery.ai/server/@gourav221b/Github-PR-MCP-server)
 
+<a href="https://glama.ai/mcp/servers/@gourav221b/Github-PR-MCP-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gourav221b/Github-PR-MCP-server/badge" alt="GitHub PR Server MCP server" />
+</a>
+
 An MCP (Model-Controller-Presenter) server built with TypeScript for analyzing GitHub Pull Requests.
 
 ## Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [GitHub PR MCP Server](https://glama.ai/mcp/servers/@gourav221b/Github-PR-MCP-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gourav221b/Github-PR-MCP-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gourav221b/Github-PR-MCP-server/badge" alt="GitHub PR Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.